### PR TITLE
feat!: add support to oboukili/argocd >= v5

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,4 @@ _In most cases, you can leave out details about how a change has been made. Code
 
 ## Tests executed on which distribution(s)
 
-- [ ] KinD
 - [ ] AKS (Azure)
-- [ ] EKS (AWS)
-- [ ] Scaleway
-- [ ] SKS (Exoscale)

--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ module "azure-workload-identity" {
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
@@ -38,9 +38,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>>
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -86,7 +86,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0"`
+Default: `"v0.1.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -156,7 +156,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -165,9 +165,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
 = Resources
@@ -202,7 +202,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0"`
+|`"v0.1.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/main.tf
+++ b/main.tf
@@ -66,14 +66,19 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
 
       retry {
-        backoff = {
-          duration     = ""
-          max_duration = ""
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
         }
-        limit = "0"
+        limit = "5"
       }
 
       sync_options = [

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source  = "oboukili/argocd"
-      version = ">= 4"
+      version = ">= 5"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

This PR adds support to the Argo CD Terraform provider version >= 5, which is needed to support versions of Argo CD >= 2.7.x.

:warning: **Do a _Rebase and merge_** :warning:

## Breaking change

- [x] Yes (in the module itself): see https://github.com/oboukili/terraform-provider-argocd/releases/tag/v5.0.0

## Tests executed on which distribution(s)

- [ ] AKS (Azure)